### PR TITLE
 fix(UX-1315): Update license 

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -38,5 +38,5 @@ jobs:
               repo: 'zeta',
               workflow_id: 'deploy.yml',
               ref: 'main',
-              environment: 'stage',
+              environment: 'production',
             })

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,21 @@
-Copyright 2024 Zebra Technologies
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2024 Zebra Technologies Inc.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/src/theme/color_swatch.dart
+++ b/lib/src/theme/color_swatch.dart
@@ -5,7 +5,13 @@ import 'color_extensions.dart';
 import 'colors_base.dart';
 import 'contrast.dart';
 
-/// A swatch of colors with values from 10 (light) to 100 (dark).
+/// {@template zeta-color-swatch}
+///  A swatch of colors with values from 10 (light) to 100 (dark).
+///
+/// See also:
+/// * [MaterialColor].
+/// {@endtemplate}
+///
 /// {@category Theme}
 @immutable
 class ZetaColorSwatch extends ColorSwatch<int> with EquatableMixin {

--- a/lib/src/theme/colors_base.dart
+++ b/lib/src/theme/colors_base.dart
@@ -52,12 +52,7 @@ abstract final class ZetaColorBase {
 
   /// Pure
   ///
-  /// {@template zeta-color-swatch}
-  /// Contains shades from 10 (light) to 100 (dark).
-  ///
-  /// See also:
-  /// * [ZetaColorSwatch].
-  /// {@endtemplate}
+  /// {@macro zeta-color-swatch}
   static const ZetaColorSwatch pure = ZetaColorSwatch(
     primary: 0xFF151519,
     swatch: {


### PR DESCRIPTION
License file did not state the license type at the top, as is required by pub.dev, so the licence appeared as "(pending)". To fix this issue, I have cloned the license file from zds_flutter, which was working correctly.

fix(UX-1316): Update macro description 
ci(UX-1272): Update release action workflow dispatch 